### PR TITLE
feat(field-teammate): added calibrated registration contracts

### DIFF
--- a/contracts/fixtures/field_teammate_hololens.json
+++ b/contracts/fixtures/field_teammate_hololens.json
@@ -38,6 +38,8 @@
     "camera_frame": "field_teammate_1/camera",
     "topics": {
       "first_person_video": "/field_teammate_1/fpv/image_raw/compressed",
+      "first_person_video_camera_pose": "/field_teammate_1/fpv/camera_pose",
+      "first_person_video_camera_info": "/field_teammate_1/fpv/camera_info",
       "localization_confidence": "/field_teammate_1/localization_confidence",
       "guidance_request": "/field_teammate_1/guidance/request",
       "guidance_response": "/field_teammate_1/guidance/response",

--- a/python/examples/FIELD_TEAMMATE_DEMO.md
+++ b/python/examples/FIELD_TEAMMATE_DEMO.md
@@ -77,13 +77,52 @@ The HoloLens does **not** connect to `horus_ros2` or HorusLink directly. The
 live path is:
 
 ```text
-HORUS Lenses app on HoloLens
+HORUS Field app on HoloLens
   -> headset pose/PV stream ports
   -> offboard relay on this machine
   -> ROS 2 topics
   -> horus_ros2 bridge
   -> HORUS MR operators
 ```
+
+### Canonical live UI and voice test
+
+Use the managed connector launch when testing the physical HoloLens, unified
+main panel, or live voice. The connector and registration names must match
+exactly because the entity name is also the voice room.
+
+```bash
+# Terminal 1: HoloLens pose/PV/control relay plus voice signaling.
+cd ~/horus_connector
+./horus setup teammate       # only when the HoloLens IP/name changed
+./horus doctor teammate
+./horus stop
+./horus launch teammate
+```
+
+In a second terminal, source ROS and register the name configured as
+`FIELD_TEAMMATE_NAME` in `~/horus_connector/.env`:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source ~/horus_ws/install/setup.bash
+set -a
+source ~/horus_connector/.env
+set +a
+cd ~/horus_sdk
+export PYTHONPATH="$PWD/python${PYTHONPATH:+:$PYTHONPATH}"
+python3 python/examples/field_teammate_registration.py --name "$FIELD_TEAMMATE_NAME"
+```
+
+Keep both terminals running. Connect HORUS MR to its normal bridge on port
+`10000`, accept the workspace, start live voice on Quest, and accept it from
+the HoloLens main panel. Stop registration with `Ctrl+C`, then run
+`./horus stop` in the connector checkout.
+
+The `--live-hololens` SDK convenience flag below starts the stream relay
+directly. It is useful for stream/registration debugging, but the managed
+`./horus launch teammate` path above is preferred for voice because it also
+owns signaling lifecycle and automatic HoloLens voice configuration.
 
 The HoloLens app displays the device IP and configured ports in its status
 panel. The default companion-app profile exposes:

--- a/python/examples/field_teammate_registration.py
+++ b/python/examples/field_teammate_registration.py
@@ -417,7 +417,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--hololens-host",
         default="",
-        help="HoloLens IPv4/hostname shown in the HORUS Lenses status panel. Required with --live-hololens.",
+        help="HoloLens IPv4/hostname shown in the HORUS Field status panel. Required with --live-hololens.",
     )
     parser.add_argument(
         "--video-profile",

--- a/python/horus/robot/config.py
+++ b/python/horus/robot/config.py
@@ -689,6 +689,8 @@ class FieldTeammateConfig:
     base_frame: str = "field_teammate/base"
     camera_frame: str = "field_teammate/camera"
     first_person_video_topic: str = ""
+    first_person_video_camera_pose_topic: str = ""
+    first_person_video_camera_info_topic: str = ""
     localization_confidence_topic: str = ""
     guidance_request_topic: str = ""
     guidance_response_topic: str = ""
@@ -718,6 +720,8 @@ class FieldTeammateConfig:
         base_frame: Any = None,
         camera_frame: Any = None,
         first_person_video_topic: Any = None,
+        first_person_video_camera_pose_topic: Any = None,
+        first_person_video_camera_info_topic: Any = None,
         localization_confidence_topic: Any = None,
         guidance_request_topic: Any = None,
         guidance_response_topic: Any = None,
@@ -772,6 +776,12 @@ class FieldTeammateConfig:
             first_person_video_topic=_topic(
                 first_person_video_topic, f"{prefix}/fpv/image_raw/compressed"
             ),
+            first_person_video_camera_pose_topic=_topic(
+                first_person_video_camera_pose_topic, f"{prefix}/fpv/camera_pose"
+            ),
+            first_person_video_camera_info_topic=_topic(
+                first_person_video_camera_info_topic, f"{prefix}/fpv/camera_info"
+            ),
             localization_confidence_topic=_topic(
                 localization_confidence_topic, f"{prefix}/localization_confidence"
             ),
@@ -812,6 +822,8 @@ class FieldTeammateConfig:
             "camera_frame": self.camera_frame,
             "topics": {
                 "first_person_video": self.first_person_video_topic,
+                "first_person_video_camera_pose": self.first_person_video_camera_pose_topic,
+                "first_person_video_camera_info": self.first_person_video_camera_info_topic,
                 "localization_confidence": self.localization_confidence_topic,
                 "guidance_request": self.guidance_request_topic,
                 "guidance_response": self.guidance_response_topic,

--- a/python/tests/test_field_teammate_payload.py
+++ b/python/tests/test_field_teammate_payload.py
@@ -229,6 +229,8 @@ def test_field_teammate_topic_contract_frozen():
     assert config.get("contract_version") == "field_teammate.v1"
     assert (config.get("topics") or {}) == {
         "first_person_video": "/field_teammate_1/fpv/image_raw/compressed",
+        "first_person_video_camera_pose": "/field_teammate_1/fpv/camera_pose",
+        "first_person_video_camera_info": "/field_teammate_1/fpv/camera_info",
         "localization_confidence": "/field_teammate_1/localization_confidence",
         "guidance_request": "/field_teammate_1/guidance/request",
         "guidance_response": "/field_teammate_1/guidance/response",
@@ -256,6 +258,8 @@ def test_field_teammate_name_is_sanitized_for_ros_topic_contract():
     assert config["camera_frame"] == "field_teammate_1_dev/camera"
     assert (config.get("topics") or {}) == {
         "first_person_video": "/field_teammate_1_dev/fpv/image_raw/compressed",
+        "first_person_video_camera_pose": "/field_teammate_1_dev/fpv/camera_pose",
+        "first_person_video_camera_info": "/field_teammate_1_dev/fpv/camera_info",
         "localization_confidence": "/field_teammate_1_dev/localization_confidence",
         "guidance_request": "/field_teammate_1_dev/guidance/request",
         "guidance_response": "/field_teammate_1_dev/guidance/response",


### PR DESCRIPTION
## Summary

Extended HORUS SDK registration to describe a live HoloLens field teammate correctly.

## Changes

- Added calibrated FPV-camera pose topics and metadata.
- Updated the field-teammate registration example.
- Updated the frozen registration contract and fixtures.
- Added coverage for the new camera and pose fields.
- Documented the managed Connector relay workflow.